### PR TITLE
Google login error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { AppState } from "./store/types";
 import { checkLogIn } from './store/actions/userActions';
 import { connect, ConnectedProps } from 'react-redux';
 import Forbidden from "./components/Forbidden/Forbidden";
+import LoginError from './components/LoginError/LoginError';
 type Props = ConnectedProps<typeof connector>;
 
 export class App extends React.Component<Props> {
@@ -33,6 +34,7 @@ export class App extends React.Component<Props> {
           <Route exact={true} path="/" component={LogIn} />
           <Route path="/login" component={LogIn} />
           <Route path="/forbidden" component={Forbidden} />
+          <Route path="/login-error" component={LoginError} />
           <PrivateRoute path="/customers" component={Layout} page='customers'  />
           <PrivateRoute path="/employees" component={Layout} page='employees' />
           <PrivateRoute path="/employees/:id" component={Layout} page='employee' />

--- a/src/components/LogIn/LogIn.tsx
+++ b/src/components/LogIn/LogIn.tsx
@@ -68,7 +68,7 @@ class LogIn extends Component<LogInProps, LogInSate> {
     };
     
     return (
-      <form id="" className="flex-column-center log-in" onSubmit={this.passwordLogIn}>
+      <form className="flex-column-center log-in" onSubmit={this.passwordLogIn}>
         {this.renderRedirect()}
 
         <img src={parkDudeLogo} alt="Parkdude logo" className="log-in-logo"/>
@@ -83,7 +83,7 @@ class LogIn extends Component<LogInProps, LogInSate> {
           onChange={this.handlePWChange}
         />
 
-        <button className="button log-in-log-button"  type="submit">Log in</button>
+        <button className="button log-in-log-button" type="submit">Log in</button>
 
         <div className="flex-row-center log-in-or-container">
           <hr/>
@@ -91,7 +91,9 @@ class LogIn extends Component<LogInProps, LogInSate> {
           <hr/>
         </div>
 
-        <button className="button log-in-google-button" onClick={this.googleLogIn}>Log in with Google</button>
+        <button type="button" className="button log-in-google-button" onClick={this.googleLogIn}>
+          Log in with Google
+        </button>
 
         <Snackbar 
           className='delete-snack'

--- a/src/components/LoginError/LoginError.css
+++ b/src/components/LoginError/LoginError.css
@@ -1,0 +1,12 @@
+.login-error-view {
+  padding-top: 10vh;
+}
+
+.login-error-view .parkdude-logo {
+  width: 560px;
+  margin-bottom: 3vh;
+}
+
+.login-error-view .button {
+  background: var(--yellow-primary);
+}

--- a/src/components/LoginError/LoginError.tsx
+++ b/src/components/LoginError/LoginError.tsx
@@ -1,0 +1,30 @@
+import React, { Component} from 'react';
+import { Link } from 'react-router-dom';
+
+import parkDudeLogo from './../../img/parkdude.svg';
+import './LoginError.css';
+
+export default class LoginError extends Component {
+  render() {
+    return (
+      <div className="flex-column-center login-error-view">
+        <img src={parkDudeLogo} alt="Parkdude logo" className="parkdude-logo"/>
+        <h3>Login error</h3>
+        <p>{this.getError() || "Login failed for unknown reason. Try again."}</p>
+        <Link to="/login" className="button">Return to login</Link>
+      </div>
+    );
+  }
+
+  getError() {
+    // Get error from query parameter
+    const url = window.location.href;
+    const key = 'error';
+    const regex = new RegExp('[?&]' + key + '(=([^&#]*)|&|#|$)');
+    const results = regex.exec(url);
+    if (!results || !results[2]) {
+      return '';
+    }
+    return decodeURIComponent(results[2].replace(/\+/g, ' '));
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -63,6 +63,16 @@ code {
   background-color: var(--red-primary);
 }
 
+a.button {
+  text-decoration: none;
+  margin: 4px 2px;
+  padding: 2px 6px 2px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+
 .button:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
Adds views needed to display Google login failure error. Currently not used, since it also needs backend change. Also includes fix to issue where Google login button would cause form submission, which again causes snackbar error to appear.

Is built on top of #29.

Is related to https://github.com/Parkdude/parkdude-mobile/issues/7.